### PR TITLE
Fix generated cuid length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ matrix:
   fast_finish: true
 cache: cargo
 script:
-  - cargo test
+  - cargo test -- --test-threads 1
   - cargo bench

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -6,11 +6,11 @@ use crate::BASE;
 use crate::error::CuidError;
 use crate::text::{pad, to_base_string};
 
-static FINGERPRINT_PADDING: u8 = 2;
+static FINGERPRINT_PADDING: usize = 2;
 
 fn pid() -> Result<String, CuidError> {
     to_base_string(process::id())
-        .map(|s| pad(FINGERPRINT_PADDING as u32, &s))
+        .map(|s| pad(FINGERPRINT_PADDING, &s))
         .map_err(|_| CuidError::FingerprintError("Could not encode pid"))
 }
 
@@ -20,7 +20,7 @@ fn convert_hostname(hn: &String) -> Result<String, CuidError> {
         hn.chars()
             .fold(hn.len() + BASE as usize, |acc, c| acc + c as usize) as u64,
     )
-    .map(|base_str| pad(FINGERPRINT_PADDING as u32, &base_str))
+    .map(|base_str| pad(FINGERPRINT_PADDING, &base_str))
 }
 
 fn host_id() -> Result<String, CuidError> {
@@ -41,7 +41,7 @@ mod fingerprint_tests {
 
     #[test]
     fn test_pid_length() {
-        assert_eq!(pid().unwrap().len(), FINGERPRINT_PADDING as usize)
+        assert_eq!(pid().unwrap().len(), FINGERPRINT_PADDING)
     }
 
     // The below expected host_ids were all generated directly using

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod time;
 pub use error::CuidError;
 
 static BASE: u8 = 36;
-static BLOCK_SIZE: u8 = 4;
+static BLOCK_SIZE: usize = 4;
 static DISCRETE_VALUES: u32 = 1679616; // BASE^BLOCK_SIZE
 static START_STR: &str = "c";
 
@@ -107,7 +107,12 @@ mod tests {
 
     #[test]
     fn correct_discrete_values() {
-        assert_eq!((BASE as u32).pow(BLOCK_SIZE as u32), DISCRETE_VALUES,);
+        assert_eq!((BASE as u32).pow(BLOCK_SIZE as u32), DISCRETE_VALUES);
+    }
+
+    #[test]
+    fn cuid_len() {
+        assert_eq!(cuid().unwrap().len(), 25);
     }
 
     #[test]

--- a/src/random.rs
+++ b/src/random.rs
@@ -22,7 +22,7 @@ fn random_64_bit_int<N: Into<f64>>(max: N) -> u64 {
 
 pub fn random_block() -> Result<String, CuidError> {
     to_base_string(random_64_bit_int(DISCRETE_VALUES as u32))
-        .map(|s| pad(BLOCK_SIZE as u32, s))
+        .map(|s| pad(BLOCK_SIZE, s))
 }
 
 
@@ -32,7 +32,7 @@ mod test_randoms {
 
     #[test]
     fn random_block_len() {
-        assert!(random_block().unwrap().len() == BLOCK_SIZE as usize)
+        assert_eq!(random_block().unwrap().len(), BLOCK_SIZE);
     }
 
     // TODO: This is theoretically a bit brittle?

--- a/src/text.rs
+++ b/src/text.rs
@@ -10,7 +10,7 @@ fn digits_in_base<N: Into<f64>>(base: u8, number: N) -> u64 {
 }
 
 
-fn to_radix_string<N: Into<u64>>(radix: u8, number: N) -> Result<String, CuidError> {
+fn to_radix_string<N: Into<u128>>(radix: u8, number: N) -> Result<String, CuidError> {
     let mut number = number.into();
     if number < radix.into() {
         // No need to allocate a vector or do any math
@@ -20,7 +20,7 @@ fn to_radix_string<N: Into<u64>>(radix: u8, number: N) -> Result<String, CuidErr
             .map(|c| c.to_string())
             .ok_or(CuidError::TextError("Bad digit"))
     }
-    else if number > f64::MAX as u64 {
+    else if number > f64::MAX as u128 {
         return Err(CuidError::TextError("Input number too large"));
     }
 
@@ -29,21 +29,20 @@ fn to_radix_string<N: Into<u64>>(radix: u8, number: N) -> Result<String, CuidErr
     );
     while number > 0 {
         chars.push(
-            char::from_digit((number % radix as u64) as u32, radix.into()).unwrap()
+            char::from_digit((number % radix as u128) as u32, radix.into()).unwrap()
         );
-        number = number / radix as u64;
+        number = number / radix as u128;
     }
     Ok(chars.iter().rev().collect::<String>())
 }
 
 
-pub fn to_base_string<N: Into<u64>>(number: N) -> Result<String, CuidError> {
+pub fn to_base_string<N: Into<u128>>(number: N) -> Result<String, CuidError> {
     to_radix_string(BASE, number)
 }
 
 
-fn pad_with_char<S: AsRef<str>>(pad_char: char, size: u32, to_pad: S) -> String {
-    let size = size as usize;
+fn pad_with_char<S: AsRef<str>>(pad_char: char, size: usize, to_pad: S) -> String {
     let pad_ref = to_pad.as_ref();
     let length = pad_ref.len();
     if length == size {
@@ -61,7 +60,7 @@ fn pad_with_char<S: AsRef<str>>(pad_char: char, size: u32, to_pad: S) -> String 
 }
 
 
-pub fn pad<S: AsRef<str>>(size: u32, to_pad: S) -> String {
+pub fn pad<S: AsRef<str>>(size: usize, to_pad: S) -> String {
     pad_with_char('0', size, to_pad.as_ref())
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -7,23 +7,28 @@ use crate::text::to_base_string;
 
 pub fn timestamp() -> Result<String, CuidError> {
     SystemTime::now().duration_since(UNIX_EPOCH)
-        .map(|time| time.as_secs())
+        .map(|time| time.as_millis())
         .map(to_base_string)
         .unwrap_or(Err(CuidError::TextError("Could not convert time to str")))
 }
 
 
-#[cfg(tests)]
+#[cfg(test)]
 mod time_tests {
     use super::*;
     use super::super::BASE;
 
     #[test]
+    fn test_timestamp_len() {
+        assert_eq!(timestamp().unwrap().len(), 8);
+    }
+
+    #[test]
     fn test_timestamp() {
         assert!(
             (
-                SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
-                - u64::from_str_radix(timestamp(), BASE)
+                SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()
+                - u128::from_str_radix(&timestamp().unwrap(), BASE as u32).unwrap()
             ) < 5
         )
     }


### PR DESCRIPTION
The currently generated cuids have variable length. Which makes this
library incompatible with the original cuid library.

This library uses seconds resolution for generating timestamps which
makes cuids more likely to collide and also increases the chance of
counter rollover.

Counter is variable-length, which makes is non-monotonic when sorted
in lexicographic order ("z" > "10" but 35 < 36).

Fix the issues above by using milliseconds resolution and padding
counter to the block size.