### PR TITLE
move proptest to dev-dependencies

### DIFF
--- a/crates/cuid2/Cargo.toml
+++ b/crates/cuid2/Cargo.toml
@@ -25,7 +25,6 @@ harness = false
 [dependencies]
 cuid-util = { path = "../cuid-util", version = "0.1.0" }
 num = { version = "0.4.0", features = ["num-bigint"] }
-proptest = "1.0.0"
 rand = "0.8.5"
 sha3 = "0.10.6"
 
@@ -33,3 +32,4 @@ sha3 = "0.10.6"
 criterion = "0.4.0"
 num_cpus = "1.15.0"
 radix_fmt = "1.0.0"
+proptest = "1.0.0"


### PR DESCRIPTION
I'm recently working on porting a crate that depends on cuid to WASM and it cannot compile due to proptest uses OS-specific APIs. After looking into the source code, it turned out that proptest is a dev dependencies and we can simply move it. This enables the cuid2 crate be compatible with `wasm32-unknown-unknown`.

Thanks for reviews!