### PR TITLE
Support changing the length of the generated ID with cuid2 binary

### DIFF
--- a/crates/cuid2/src/bin.rs
+++ b/crates/cuid2/src/bin.rs
@@ -1,18 +1,23 @@
 //! Provide a simple binary for generating v2 cuids
 
-use cuid2::create_id;
-
 use std::{env, process::exit};
+use std::str::FromStr;
+
+struct ParsedArgs {
+    pub cuid_length: u16
+}
 
 /// Generates a new CUID and print it to stdout
 pub fn main() {
-    parse_args();
+    let parsed_args = parse_args();
 
-    println!("{}", create_id());
+    println!("{}", cuid2::CuidConstructor::new()
+        .with_length(parsed_args.cuid_length)
+        .create_id());
 }
 
-const HELP: &str = r#"Usage: cuid2 [OPTION]...
-Generate and print a CUID.
+const HELP: &str = r#"Usage: cuid2 [OPTION]... [LENGTH]
+Generate and print a CUID. The default LENGTH is 24.
 
 Options:
   -h, --help     display this help and exit
@@ -20,7 +25,12 @@ Options:
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-fn parse_args() {
+fn parse_args() -> ParsedArgs {
+    // defaults here
+    let mut parsed_args = ParsedArgs {
+        cuid_length: 24
+    };
+
     // The first argument should be the binary name. Skip it.
     env::args().skip(1).for_each(|arg| match arg.as_str() {
         "-h" | "--help" => {
@@ -31,11 +41,17 @@ fn parse_args() {
             println!("{}", VERSION);
             exit(0);
         }
-        _ => {
-            println!("error: unrecognized argument {}", arg);
-            println!();
-            println!("{}", HELP);
-            exit(1);
+        length_str => {
+            if let Ok(length) = u16::from_str(length_str) {
+                parsed_args.cuid_length = length
+            } else {
+                println!("error: unrecognized argument {}", arg);
+                println!();
+                println!("{}", HELP);
+                exit(1);
+            }
         }
     });
+
+    parsed_args
 }


### PR DESCRIPTION
This PR adds an argument to the `cuid2` binary that allows changing the length of the generated ID from it's default.
```
# Original behavior
$ cuid2
ali0e7b9ryfeexl0b7akyb6v

# New behavior
$ cuid2 32
cqyxwxhpy3qyk1njfzq9jpf8b1s0ftkp
```