### PR TITLE
fix: specify version for getrandom

### DIFF
--- a/crates/cuid1/Cargo.toml
+++ b/crates/cuid1/Cargo.toml
@@ -41,7 +41,7 @@ hostname = "0.4.0"
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Just specified so we can add a feature when the js feature is enabled.
 # This works fine on wasm targets other than unknown-unknown
-getrandom = { version = "0", features = ["js"] }
+getrandom = { version = "0.2", features = ["js"] }
 web-time = "1.1.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/crates/cuid2/Cargo.toml
+++ b/crates/cuid2/Cargo.toml
@@ -42,5 +42,5 @@ proptest.workspace = true
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Just specified so we can add a feature when the js feature is enabled.
 # This works fine on wasm targets other than unknown-unknown
-getrandom = { version = "0", features = ["js"] }
+getrandom = { version = "0.2", features = ["js"] }
 web-time = "1.1.0"


### PR DESCRIPTION
`getrandom-0.3` has removed the `js` feature and [handles the JS implementation differently now](https://github.com/rust-random/getrandom?tab=readme-ov-file#opt-in-backends). Due to the version constraint being `0`, this crate doesn't compile as of that change. It'd be nice to eventually use the new version, but in the meantime I thought it'd be worth to open a PR to set the version to the last one that works which is 0.2 in order to fix the build.